### PR TITLE
Correct return from tripvote in PC optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 # PyEBSDIndex
 
-Python based tool for Hough/Radon based EBSD orienation indexing. The pattern processing is based on a GPU pipeline, and is based on the work of S. I. Wright and B. L. Adams. Metallurgical Transactions a-Physical Metallurgy and Materials Science, 23(3):759–767, 1992 
-And
-N. Krieger Lassen. Automated Determination of Crystal Orientations from Electron Backscattering Pat- terns. PhD thesis, The Technical University of Denmark, 1994.
+Python based tool for Hough/Radon based EBSD orientation indexing. The pattern
+processing is based on a GPU pipeline, and is based on the work of S. I. Wright and B.
+L. Adams. Metallurgical Transactions A-Physical Metallurgy and Materials Science,
+23(3):759–767, 1992, and N. Krieger Lassen. Automated Determination of Crystal
+Orientations from Electron Backscattering Patterns. PhD thesis, The Technical University
+of Denmark, 1994.
 
-The band indexing is achieved through triplet voting using the methods outlined by A. Morawiec. Acta Crystallographica Section A Foundations and Advances, 76(6):719–734, 2020.
+The band indexing is achieved through triplet voting using the methods outlined by A.
+Morawiec. Acta Crystallographica Section A Foundations and Advances, 76(6):719–734,
+2020.
 
-Additionally NLPAR pattern processing is included (original distribution [NLPAR](https://github.com/USNavalResearchLaboratory/NLPAR) ; P. T. Brewick, S. I. Wright, and D. J. Rowenhorst. Ultramicroscopy, 200:50–61, May 2019.)
-
-
-
+Additionally NLPAR pattern processing is included (original distribution
+[NLPAR](https://github.com/USNavalResearchLaboratory/NLPAR); P. T. Brewick, S. I.
+Wright, and D. J. Rowenhorst. Ultramicroscopy, 200:50–61, May 2019.).
 
 ## Installation
 
-The package only be installed from source at the moment:
+The package can only be installed from source at the moment:
 
 ```bash
-git clone https://github.com/drowenhorst-nrl/PyEBSDIndex
+git clone https://github.com/USNavalResearchLaboratory/PyEBSDIndex
 cd PyEBSDIndex
 pip install --editable .
 ```
-
-


### PR DESCRIPTION
Hi Dave,

tried out the PC optimization again, encountered an error, so here's a fix:
* `tripvote()` returns seven parameters, although six was used in `optfunction()`. This is fixed by only asking for the relevant parameter (second).
* Fix typos in README.

Other changes you might now want: I've made the style more readable (in my opinion) and similar to other Python projects. This means four spaces for indentation instead of two, variable names with underscores, spaces between commas, etc. It's just a suggestion. If it's unwanted, I'll make a new PR with only the two above changes. The changes enable my editor (PyCharm) to inspect the code and give me type hints and numerous other nice features which ease development.

EDIT: Pinging @drowenhorst-nrl.