### PR TITLE
Fix PC conventions and add a changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+=========
+Changelog
+=========
+
+All notable changes to PyEBSDIndex will be documented in this file. The format is based
+on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
+
+Unreleased
+==========
+
+Added
+-----
+- PC conventions for Bruker, EDAX, EMsoft, kikuchipy, and Oxford.

--- a/pyebsdindex/band_detect.py
+++ b/pyebsdindex/band_detect.py
@@ -414,7 +414,7 @@ class BandDetect():
       t *= np.array([dimf[1], dimf[1], -dimf[1]])
     if ven == 'EMSOFT':
       t += np.array([dimf[1] / 2.0, dimf[0] / 2.0, 0.0])
-      t[:, 2] *= -1
+      t[:, 2] *= -1.0
     if ven in ['KIKUCHIPY', 'BRUKER']:
       t *=  np.array([dimf[1], dimf[0], -dimf[0]])
       t[:, 1] = dimf[0] - t[:, 1]

--- a/pyebsdindex/band_detect.py
+++ b/pyebsdindex/band_detect.py
@@ -401,7 +401,7 @@ class BandDetect():
     stheta = np.sin(theta)
     ctheta = np.cos(theta)
 
-    t = (np.asfarray(PC)).copy()
+    t = np.asfarray(PC).copy()
     shapet = t.shape
     if len(shapet) < 2:
       t = np.tile(t, nPats).reshape(nPats,3)
@@ -409,16 +409,15 @@ class BandDetect():
       if shapet[0] != nPats:
         t = np.tile(t[0,:], nPats).reshape(nPats,3)
 
-
     dimf = np.array(self.patDim, dtype=np.float32)
-    if (ven in ['EDAX', 'OXFORD']) :
-      t *= np.array([dimf[1],dimf[1],-1.0 * dimf[1]])
-    if (ven == 'EMSOFT'):
-      t += np.array([dimf[1] / 2.0,dimf[0] / 2.0,0.0])
-      t[2,:] *= -1.0
+    if ven in ['EDAX', 'OXFORD']:
+      t *= np.array([dimf[1], dimf[1], -dimf[1]])
+    if ven == 'EMSOFT':
+      t += np.array([dimf[1] / 2.0, dimf[0] / 2.0, 0.0])
+      t[:, 2] *= -1
     if ven in ['KIKUCHIPY', 'BRUKER']:
-      t *=  np.array([dimf[1],dimf[0],-1.0 *dimf[0]])
-      t[1,:] = dimf[0] - t[1,:]
+      t *=  np.array([dimf[1], dimf[0], -dimf[0]])
+      t[:, 1] = dimf[0] - t[:, 1]
     # describes the translation from the bottom left corner of the pattern image to the point on the detector
     # perpendicular to where the beam contacts the sample.
 


### PR DESCRIPTION
* Fix the PC conventions by indexing correctly into the Fortran NumPy array `t`.
* Add a changelog, which can be used to communicate new features and the like to users, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). In the future, this changelog can be added as-is to a documentation page similar to [kikuchipy's changelog](https://kikuchipy.org/en/stable/changelog.html).

I checked the supported vendor conventions in `pyebsdindex.ebsd_index.EBSDIndexer.index_pats()`, and they now work with the conventions used in kikuchipy, with one exception: The EMsoft convention here corresponds to the [EMsoft v4 convention in kikuchipy](https://kikuchipy.org/en/stable/reference.html#kikuchipy.detectors.EBSDDetector.pc_emsoft)... I believe it is correct here, and wrong in kikuchipy, because in EMsoft >= 5.0, the detector screen is viewed towards the sample, and xpc increases towards the right from the middle of the detector. Could you confirm that it's the EMsoft v5 convention you implemented?

Should close #3.