### PR TITLE
Minor repairs

### DIFF
--- a/pyebsdindex/clkernels.cl
+++ b/pyebsdindex/clkernels.cl
@@ -155,8 +155,8 @@ __kernel void convolution3d2d( __global const float16 *in, __constant float *ker
   const unsigned long int nImChunk = get_global_size(2);
   //long int indxIm; 
   //long int indxK;
-  long unsigned long yIndx; 
-  long unsigned long yKIndx; 
+  unsigned long yIndx; 
+  unsigned long yKIndx; 
   float16 pxVal;
   float16 sum = (float16) (0.0f); // initialize convolution sum
   float kVal;

--- a/pyebsdindex/ebsd_index.py
+++ b/pyebsdindex/ebsd_index.py
@@ -43,11 +43,11 @@ from pyebsdindex import (
 )
 from pyebsdindex.EBSDImage import IPFcolor
 
-
-if ray.__version__ < '1.1.0':  # this fixes an issue when running locally on a VPN
-  ray.services.get_node_ip_address = lambda: '127.0.0.1'
-else:
-  ray._private.services.get_node_ip_address = lambda: '127.0.0.1'
+# if sys.platform == 'darwin':
+#   if ray.__version__ < '1.1.0':  # this fixes an issue when running locally on a VPN
+#     ray.services.get_node_ip_address = lambda: '127.0.0.1'
+#   else:
+#     ray._private.services.get_node_ip_address = lambda: '127.0.0.1'
 
 RADEG = 180.0 / np.pi
 
@@ -130,7 +130,7 @@ def index_pats_distributed(patsIn=None,filename=None,filenameout=None,phaselist=
   ray.shutdown()
 
   #ray.init(num_cpus=n_cpu_nodes,num_gpus=ngpu,_system_config={"maximum_gcs_destroyed_actor_cached_count": n_cpu_nodes})
-  ray.init(num_cpus=n_cpu_nodes,num_gpus=ngpu)
+  ray.init(num_cpus=n_cpu_nodes,num_gpus=ngpu, _node_ip_address="0.0.0.0")
   pats = None
   if patsIn is None:
     pdim = None


### PR DESCRIPTION
Fixes the odd use of 128-bit long ints in the opencl code (some compilers/cards did not like).
Perhaps a more universal method for getting ray (distributed processing) to initialize on local machine, even when on a VPN. The older method was having some issues with some firewalls.  