### PR TITLE
Avoid ray v1.12.0 due to an import error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,3 +11,7 @@ Unreleased
 Added
 -----
 - PC conventions for Bruker, EDAX, EMsoft, kikuchipy, and Oxford.
+
+Fixed
+-----
+- ray package version 1.12.0 is avoided due to an import error on Windows.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -14,7 +14,7 @@ Preparation
 
 Release (and tag)
 -----------------
-- Create a tagged, annotated (meaning with a release text) with the name
+- Create a tagged, annotated (meaning with a release text) release draft with the name
   v0.4.2" and title "PyEBSDIndex 0.4.2". The tag target will be the ``main`` branch.
   Draw inspiration from previous release texts. Publish the release.
 - Monitor the publish GitHub Action to ensure the release is successfully

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup(
         "numpy",
         "numba",
         "pyswarms",
-        "ray[default]",
+        # See https://github.com/ray-project/ray/issues/24169
+        "ray[default] != 1.12.0",
         "scipy",
     ],
     # Files to include when distributing package


### PR DESCRIPTION
[Tests](https://github.com/USNavalResearchLaboratory/PyEBSDIndex/runs/6083498964?check_suite_focus=true) fail on Windows. The issue is related to an import error from `ray` v1.12.0. According to [this issue](https://github.com/ray-project/ray/issues/24169), it will be fixed in v1.12.1. I've updated the dependency list to avoid ray v1.12.0.