### PR TITLE
Add MANIFEST.in file to ensure distribution includes relevant files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,23 @@ name: Build
 on: [push, pull_request]
 
 jobs:
+  # Make sure all necessary files are included in a release
+  check-manifest:
+    name: check manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+
+      - name: Install dependencies
+        run: |
+          pip install manifix
+
+      - name: Check MANIFEST.in file
+        run: |
+          python setup.py manifix
+
   build-with-pip:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}
     runs-on: ${{ matrix.os }}
@@ -16,26 +33,32 @@ jobs:
         python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies and package
         shell: bash
         run: |
           pip install --upgrade --editable .'[tests]'
+
       - name: Install GPU support
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
         run: |
           pip install --upgrade --editable .'[gpu]'
+
       - name: Display versions of Python, pip and packages
         run: |
           python -V
           pip -V
           pip list
+
       - name: Run tests
         run: |
           pytest --cov=pyebsdindex --pyargs pyebsdindex
+
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.9, '3.10']
+        include:
+          - os: ubuntu-latest
+            python-version: 3.8
+            OLDEST_SUPPORTED_VERSION: true
+            DEPENDENCIES: matplotlib==3.3 numba==0.52 numpy==1.19 ray[default]==1.13
+            LABEL: -oldest
     steps:
       - uses: actions/checkout@v2
 
@@ -43,6 +49,11 @@ jobs:
         shell: bash
         run: |
           pip install --upgrade --editable .'[tests]'
+
+      - name: Install oldest supported version
+        if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
+        run: |
+          pip install ${{ matrix.DEPENDENCIES }}
 
       - name: Install GPU support
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
 
 Added
 -----
+- Support for Python 3.10.
 - ``ebsd_index`` functions return both the orientation data and band identification data
   from the Radon transform.
 - QUEST algorithm to get a best fit for the orientation.
@@ -18,4 +19,6 @@ Added
 
 Fixed
 -----
-- Maximum version of ray package set to < 1.12.0 to avoid an import error on Windows.
+- Minimum version of ``ray`` package set to >= 1.13.
+- Maximum version of ``ray`` package set to < 1.12.0 to avoid an import error on
+  Windows.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+include .readthedocs.yaml
+include CHANGELOG.rst
+include CONTRIBUTING.rst
+include IPFCubic.pdf
+include IPFCubic.png
+include License
+include MANIFEST.in
+include README.md
+include RELEASE.rst
+include setup.cfg
+include setup.py
+
+recursive-include pyebsdindex *.png *.cl *.py
+recursive-include doc Makefile make.bat *.rst *.py *.ipynb

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -7,7 +7,7 @@ recommended to use a virtual environment, such as venv or conda environments.
 
 The package can be installed from the `Python Package Index
 <https://pypi.org/project/pyebsdindex>`_ (``pip``) or from source on all operating
-systems::
+systems with Python >= 3.8::
 
     pip install pyebsdindex
 
@@ -62,8 +62,8 @@ The ``ray`` package used for distributed multi-processing only experimentally su
 Apple's ARM64 architecture. More info is available `here
 <https://docs.ray.io/en/latest/ray-overview/installation.html>`_. In brief, to run on
 Apple ARM64, PyEBSDIndex should be installed in a conda environment. Assuming that
-``ray`` has already been installed (perhaps as a dependency) one has activated the conda
-environment in the terminal, run the commands below (the first two commands are to
+``ray`` has already been installed (perhaps as a dependency) and one has activated the
+conda environment in the terminal, run the commands below (the first two commands are to
 guarantee that ``grpcio`` is fully removed, they may send a message that the packages
 are not installed)::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,14 @@
 [metadata]
 license_files = License
+
+[manifix]
+known_excludes =
+    .*
+    .*/**
+    .git/**
+    **/*.pyc
+    **/*.nbi
+    **/*.nbc
+    doc/build*
+    doc/.ipynb_checkpoints/*
+    htmlcov/**

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,20 @@ from pyebsdindex import (
 extra_feature_requirements = {
     "doc": [
         "furo",
-        "nbsphinx >= 0.7",
-        "sphinx >= 3.0.2",
-        "sphinx-copybutton >= 0.2.5",
-        "sphinx-gallery >= 0.6",
+        "nbsphinx           >= 0.7",
+        "sphinx             >= 3.0.2",
+        "sphinx-copybutton  >= 0.2.5",
+        "sphinx-gallery     >= 0.6",
     ],
-    "tests": ["coverage >= 5.0", "pytest >= 5.4", "pytest-cov >= 2.8.1"],
+    "tests": [
+        "coverage   >= 5.0",
+        "pytest     >= 5.4",
+        "pytest-cov >= 2.8.1"
+    ],
     "gpu": ["pyopencl"],
 }
-# Create a development project, including both the docs and tests projects
+# Create a development project, including both the docs and tests
+# projects
 extra_feature_requirements["dev"] = list(
     chain(*list(extra_feature_requirements.values()))
 )
@@ -39,6 +44,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: Other/Proprietary License",
@@ -73,19 +79,10 @@ setup(
         "numpy",
         "numba",
         "pyswarms",
-        # See https://github.com/ray-project/ray/issues/24169
-        "ray[default] < 1.12.0",
+        "ray[default] >= 1.13",
         "scipy",
     ],
     # Files to include when distributing package
     packages=find_packages(),
     package_dir={"pyebsdindex": "pyebsdindex"},
-    include_package_data=True,
-    package_data={
-        "pyebsdindex": [
-            "*.py",
-            "*.cl",
-            "tests/data/al_sim_20kv/al_sim_20kv.png",
-        ],
-    },
 )


### PR DESCRIPTION
As suggested by @drowenhorst-nrl in #22, this PR adds a `MANIFEST.in` file listing the relevant files to include in the source distribution uploaded to PyPI.

It also adds a CI check (run on every PR and push to `main`) ensuring that all source files are listed for inclusion or exclusion using the `manifix` Python package. By running `python setup.py manifix`, a `pyebsdindex.egg_info` directory with a `SOURCES.txt` file is created, listing all files which will be included in the source distribution. Running this *before* including the `MANIFEST.in` produces this list:

```
License
README.md
setup.cfg
setup.py
pyebsdindex/__init__.py
pyebsdindex/band_detect.py
pyebsdindex/band_vote.py
pyebsdindex/crystal_sym.py
pyebsdindex/crystallometry.py
pyebsdindex/ebsd_index.py
pyebsdindex/ebsd_pattern.py
pyebsdindex/nlpar.py
pyebsdindex/pairlib.py
pyebsdindex/pcopt.py
pyebsdindex/radon_fast.py
pyebsdindex/rotations.py
pyebsdindex/rotlib.py
pyebsdindex/spherical_radon_fast.py
pyebsdindex/tripletlib.py
pyebsdindex.egg-info/PKG-INFO
pyebsdindex.egg-info/SOURCES.txt
pyebsdindex.egg-info/dependency_links.txt
pyebsdindex.egg-info/requires.txt
pyebsdindex.egg-info/top_level.txt
pyebsdindex.egg-info/zip-safe
pyebsdindex/EBSDImage/IPFcolor.py
pyebsdindex/EBSDImage/__init__.py
pyebsdindex/opencl/__init__.py
pyebsdindex/opencl/band_detect_cl.py
pyebsdindex/opencl/openclparam.py
pyebsdindex/opencl/radon_fast_cl.py
pyebsdindex/tests/__init__.py
pyebsdindex/tests/conftest.py
pyebsdindex/tests/numbatest.py
pyebsdindex/tests/raytest.py
pyebsdindex/tests/rotlibunittest.py
pyebsdindex/tests/test_ebsd_index.py
pyebsdindex/tests/test_pcopt.py
pyebsdindex/tests/data/al_sim_20kv/al_sim_20kv.png
```

Running `manifix` again after including `MANIFEST.in` produces this list:

```
.readthedocs.yaml
CHANGELOG.rst
CONTRIBUTING.rst
IPFCubic.pdf
IPFCubic.png
License
MANIFEST.in
README.md
RELEASE.rst
setup.cfg
setup.py
doc/Makefile
doc/NLPAR_demo.ipynb
doc/changelog.rst
doc/conf.py
doc/contributing.rst
doc/ebsd_index_demo.ipynb
doc/index.rst
doc/installation.rst
doc/make.bat
doc/reference.rst
pyebsdindex/__init__.py
pyebsdindex/band_detect.py
pyebsdindex/band_vote.py
pyebsdindex/crystal_sym.py
pyebsdindex/crystallometry.py
pyebsdindex/ebsd_index.py
pyebsdindex/ebsd_pattern.py
pyebsdindex/nlpar.py
pyebsdindex/pairlib.py
pyebsdindex/pcopt.py
pyebsdindex/radon_fast.py
pyebsdindex/rotations.py
pyebsdindex/rotlib.py
pyebsdindex/spherical_radon_fast.py
pyebsdindex/tripletlib.py
pyebsdindex.egg-info/PKG-INFO
pyebsdindex.egg-info/SOURCES.txt
pyebsdindex.egg-info/dependency_links.txt
pyebsdindex.egg-info/requires.txt
pyebsdindex.egg-info/top_level.txt
pyebsdindex.egg-info/zip-safe
pyebsdindex/EBSDImage/IPFcolor.py
pyebsdindex/EBSDImage/__init__.py
pyebsdindex/opencl/__init__.py
pyebsdindex/opencl/band_detect_cl.py
pyebsdindex/opencl/clkernels.cl
pyebsdindex/opencl/openclparam.py
pyebsdindex/opencl/radon_fast_cl.py
pyebsdindex/tests/__init__.py
pyebsdindex/tests/conftest.py
pyebsdindex/tests/numbatest.py
pyebsdindex/tests/raytest.py
pyebsdindex/tests/rotlibunittest.py
pyebsdindex/tests/test_ebsd_index.py
pyebsdindex/tests/test_pcopt.py
pyebsdindex/tests/data/al_sim_20kv/al_sim_20kv.png
pyebsdindex/tests/data/al_sim_20kv/generate_al_sim_20kv.py
```

We see that `clkernels.cl` is included, which should thus fix #22.

---

This PR also sets the minimum version of `ray>=1.13` released on June 9 which fixes an error in versions below `1.13`. Apparently, it's not available for Python 3.10 on Windows, but hopefully it will be soon. With this change, PyEBSDIndex should support Python 3.10 on macOS and Linux, at least.