### PR TITLE
Add Anaconda to installation instructions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
 
 Added
 -----
+- Installation from Anaconda on Linux and Windows for Python 3.8 and 3.9.
 - Support for Python 3.10.
 - ``ebsd_index`` functions return both the orientation data and band identification data
   from the Radon transform.

--- a/README.md
+++ b/README.md
@@ -20,72 +20,10 @@ Additionally NLPAR pattern processing is included (original distribution
 [NLPAR](https://github.com/USNavalResearchLaboratory/NLPAR); P. T. Brewick, S. I.
 Wright, and D. J. Rowenhorst. Ultramicroscopy, 200:50–61, May 2019.).
 
-Documentation with a user guide, API reference, changelog, and contributing guide is
-available at https://pyebsdindex.readthedocs.io.
+Documentation with installation instructions, a user guide, API reference, changelog,
+and contributing guide is available at https://pyebsdindex.readthedocs.io.
 
 ## Installation
-In order to avoid potential conflicts with other system python packages, it is strongly recommended 
-to use a virtual environment, such as venv or conda environments.  
 
-The package can be installed from the
-[Python Package Index](https://pypi.org/project/pyebsdindex) (`pip`) or from source on
-all operating systems:
-
-```bash
-pip install pyebsdindex
-```
-
-Installing with optional GPU support via `pyopencl`:
-
-```bash
-pip install pyebsdindex[gpu]
-```
-
-Please refer to the [pyopencl](https://documen.tician.de/pyopencl/misc.html)
-installation documentation in case installation fails.
-
-Installing the package from source with optional dependencies for running tests
-
-```bash
-git clone https://github.com/USNavalResearchLaboratory/PyEBSDIndex
-cd PyEBSDIndex
-pip install --editable .[tests]
-```
-
-Also, if you want to run the example jupyter notebooks in the documentation, 
-you will need to install jypterlab:
-
-```bash
-pip install jupyterlab
-```
-or 
-```bash
-conda install jupyterlab
-```
-
-## Additional installation notes
-### MacOS
-The latest versions of pyopencl installed from conda-forge do not automatically include linking
-to the MacOS OpenCL framework. If using a conda environment, it may be necessary to install: 
-```bash
-conda install -c conda-forge ocl_icd_wrapper_apple
-```
-
-Apple in recent installs has switched to zsh as the default shell.  It should be noted that zsh sees \[...\]  as a pattern.  Thus commands like: 
-```bash
-pip install pyebsdindex[gpu]
-```
-Will return an error.  "zsh: no matches found: [gpu]".  The solution is to put the comand within '...' such as:
-```bash
-pip install 'pyebsdindex[gpu]'
-```
-
-
-### MacOS with Apple Silicon
-The Ray package used for distributed multi-processing only experimentally supports Apple's ARM64 architecture. More info is available [here](https://docs.ray.io/en/latest/ray-overview/installation.html).  In brief, to run on Apple ARM64, PyEBSDIndex should be installed in a conda environment.  Assuming that Ray has already been installed (perhaps as a dependency) one has activated the conda environment in the terminal, run the commands below (the first two commands are to guarantee that grpcio is fully removed, they may send a message that the packages are not installed.):
-```bash
-pip uninstall ray
-pip uninstall grpcio
-conda install -c conda-forge grpcio
-pip install 'ray[default]'
-```
+See [the documentation](https://pyebsdindex.readthedocs.io/en/latest/installation.html)
+for installation instructions.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -2,30 +2,46 @@
 Installation
 ============
 
-In order to avoid potential conflicts with other system python packages, it is strongly
-recommended to use a virtual environment, such as venv or conda environments.
+The package can be installed from the Python Package Index (``pip``) or from source on
+all operating systems with Python >= 3.8, and from Anaconda on Linux or Windows with
+Python 3.8 and 3.9.
 
-The package can be installed from the `Python Package Index
-<https://pypi.org/project/pyebsdindex>`_ (``pip``) or from source on all operating
-systems with Python >= 3.8::
+In order to avoid potential conflicts with other system Python packages, it is strongly
+recommended to use a virtual environment, such as ``venv`` or ``conda`` environments.
+
+With pip
+========
+
+Installing with ``pip``::
 
     pip install pyebsdindex
 
-Installing with optional GPU support via ``pyopencl``::
+Installing with optional GPU support from ``pyopencl``::
 
     pip install pyebsdindex[gpu]
 
 Please refer to the `pyopencl <https://documen.tician.de/pyopencl/misc.html>`_
 installation documentation in case installation fails.
 
+From Anaconda
+=============
+
+Installing from Anaconda on Linux or Windows (with ``jupyterlab`` and GPU support
+included)::
+
+    conda install -c conda-forge/label/pyebsdindex_rc pyebsdindex
+
+From source
+===========
+
 Installing the package from source with optional dependencies for running tests::
 
     git clone https://github.com/USNavalResearchLaboratory/PyEBSDIndex
     cd PyEBSDIndex
-    pip install --editable .[tests]
+    pip install -e .[tests]
 
 Also, if you want to run the example Jupyter notebooks in the documentation, you will
-need to install ``jypterlab``::
+need to install ``jupyterlab``::
 
     pip install jupyterlab
 
@@ -39,18 +55,18 @@ Additional installation notes
 MacOS
 -----
 
-The latest versions of ``pyopencl`` installed from conda-forge do not automatically
-include linking to the MacOS OpenCL framework. If using a conda environment, it may be
+The latest versions of ``pyopencl`` installed from Anaconda do not automatically include
+linking to the MacOS OpenCL framework. If using a ``conda`` environment, it may be
 necessary to install::
 
     conda install -c conda-forge ocl_icd_wrapper_apple
 
-Apple in recent installs has switched to ``zsh`` as the default shell.  It should be
+Apple in recent installs has switched to ``zsh`` as the default shell. It should be
 noted that ``zsh`` sees ``\[...\]`` as a pattern. Thus commands like::
 
     pip install pyebsdindex[gpu]
 
-Will return an error ``"zsh: no matches found: [gpu]"``. The solution is to put the
+will return an error ``"zsh: no matches found: [gpu]"``. The solution is to put the
 command within ``'...'`` such as::
 
     pip install 'pyebsdindex[gpu]'
@@ -61,7 +77,7 @@ MacOS with Apple Silicon
 The ``ray`` package used for distributed multi-processing only experimentally supports
 Apple's ARM64 architecture. More info is available `here
 <https://docs.ray.io/en/latest/ray-overview/installation.html>`_. In brief, to run on
-Apple ARM64, PyEBSDIndex should be installed in a conda environment. Assuming that
+Apple ARM64, PyEBSDIndex should be installed in a ``conda`` environment. Assuming that
 ``ray`` has already been installed (perhaps as a dependency) and one has activated the
 conda environment in the terminal, run the commands below (the first two commands are to
 guarantee that ``grpcio`` is fully removed, they may send a message that the packages


### PR DESCRIPTION
PyEBSDIndex can now be installed on Windows and Linux with Python 3.8 or 3.9 from Anaconda like this

```bash
conda install -c conda-forge/label/pyebsdindex_rc pyebsdindex
```

I've added this option to the installation instructions.

I've also removed the installation instructions from the README, pointing instead to the instructions on Read The Docs, so that we don't have to repeat ourselves. If this is undesirable @drowenhorst-nrl, I'll re-add the instructions to the README.

The Anaconda channel is not just `conda-forge` since PyEBSDIndex only has prereleases available from PyPI. In order for the channel to just be `conda-forge`, we need to make a "proper" release of PyEBSDIndex with a version without "rc" or "dev" in it.