### PR TITLE
Update installation instructions and prepare for 0.1.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog
 All notable changes to PyEBSDIndex will be documented in this file. The format is based
 on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
 
-0.1.0 - Release date
-====================
+0.1.0 (2022-07-12)
+==================
 
 Added
 -----

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -2,9 +2,9 @@
 Installation
 ============
 
-The package can be installed from the Python Package Index (``pip``) or from source on
-all operating systems with Python >= 3.8, and from Anaconda on Linux or Windows with
-Python 3.8 and 3.9.
+The package can be installed with `pip <https://pypi.org/project/pyebsdindex>`__ or from
+source on all operating systems with Python >= 3.7, and from Anaconda on Linux or
+Windows with Python 3.8 and 3.9.
 
 In order to avoid potential conflicts with other system Python packages, it is strongly
 recommended to use a virtual environment, such as ``venv`` or ``conda`` environments.
@@ -12,16 +12,26 @@ recommended to use a virtual environment, such as ``venv`` or ``conda`` environm
 With pip
 ========
 
-Installing with ``pip``::
+Installing all of PyEBSDIndex' functionalities with ``pip``::
+
+    pip install pyebsdindex[all]
+
+To install only the strictly required rependencies and limited functionalities, use::
 
     pip install pyebsdindex
 
-Installing with optional GPU support from ``pyopencl``::
+See the following list of selectors to select the installation of optional dependencies
+required for specific functionality:
 
-    pip install pyebsdindex[gpu]
-
-Please refer to the `pyopencl <https://documen.tician.de/pyopencl/misc.html>`_
-installation documentation in case installation fails.
+- ``gpu`` - GPU support from `pyopencl
+  <https://documen.tician.de/pyopencl/misc.html>`__. Please refer to the pyopencl
+  installation documentation in case installation fails.
+- ``parallel`` - Parallel indexing from `ray[default]
+  <https://docs.ray.io/en/latest/>`__.
+- ``all`` - Install the dependencies in the above selectors.
+- ``doc`` - Dependencies to build the documentation.
+- ``tests`` - Dependencies to run tests.
+- ``dev`` - Install dependencies in the above selectors.
 
 From Anaconda
 =============

--- a/pyebsdindex/__init__.py
+++ b/pyebsdindex/__init__.py
@@ -7,7 +7,7 @@ __credits__ = [
 ]
 __description__ = "Python based tool for Hough/Radon based EBSD indexing"
 __name__ = "pyebsdindex"
-__version__ = "0.1dev0"
+__version__ = "0.1.0"
 
 
 # Try to import only once


### PR DESCRIPTION
As mentioned in #28, we could make a "proper" release 0.1.0 (a non-prerelease). I've updated the package version and changelog accordingly.

Making a release of the tag "v0.1.0" from the "main" branch will release this on PyPI. We can then make a new conda-forge release so that the package is installable as `conda install pyebsdindex -c conda-forge`. If this release is made, we can start to depend on PyEBSDIndex in kikuchipy as well.

I've also described the `pip` selectors (`pip install pyebsdindex[all]` etc.) in the installation guide.