### PR TITLE
Prepare v0.1.1 patch release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog
 All notable changes to PyEBSDIndex will be documented in this file. The format is based
 on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
 
-Unreleased
-==========
+0.1.1 (2022-10-25)
+==================
 
 Added
 -----

--- a/pyebsdindex/__init__.py
+++ b/pyebsdindex/__init__.py
@@ -7,7 +7,7 @@ __credits__ = [
 ]
 __description__ = "Python based tool for Hough/Radon based EBSD indexing"
 __name__ = "pyebsdindex"
-__version__ = "0.2.dev0"
+__version__ = "0.1.1"
 
 
 # Try to import only once


### PR DESCRIPTION
I suggest to release the bug fixes in `main`.

I suggest this release text:

> PyEBSDIndex 0.1.1 is a patch release of PyEBSDIndex, a Python based tool for Hough/Radon based EBSD orientation indexing.
>
> This release fixes batch optimization of pattern centers and ensures that some OpenCL kernels and test data are included in the source distribution.
>
> See the [changelog](https://pyebsdindex.readthedocs.io/en/latest/changelog.html) or the [GitHub changelog](https://github.com/USNavalResearchLaboratory/PyEBSDIndex/compare/v0.1.0...v0.1.1) for all updates.

If you're OK with this @drowenhorst-nrl, I'll publish a release with this text after this PR is merged.