### PR TITLE
Post v0.1.1 release updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,27 @@ Changelog
 All notable changes to PyEBSDIndex will be documented in this file. The format is based
 on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
 
+Unreleased
+==========
+
+Added
+-----
+
+Changed
+-------
+
+Deprecated
+----------
+
+Removed
+-------
+
+Fixed
+-----
+
+Security
+--------
+
 0.1.1 (2022-10-25)
 ==================
 

--- a/pyebsdindex/__init__.py
+++ b/pyebsdindex/__init__.py
@@ -7,7 +7,7 @@ __credits__ = [
 ]
 __description__ = "Python based tool for Hough/Radon based EBSD indexing"
 __name__ = "pyebsdindex"
-__version__ = "0.1.1"
+__version__ = "0.2.dev0"
 
 
 # Try to import only once


### PR DESCRIPTION
PyEBSDIndex 0.1.1 is released on PyPI, with conda-forge to follow once their bot makes a PR.

This PR reverts the version from 0.1.1 to 0.2.dev0 and adds the "Unreleased" section to the changelog.