### PR TITLE
Small improvements to use of Matplotlib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,18 @@
 name: Build
 
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+    workflow: '*'
+
+env:
+  MPLBACKEND: agg
 
 jobs:
   # Make sure all necessary files are included in a release
@@ -8,9 +20,11 @@ jobs:
     name: check manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |
@@ -24,8 +38,6 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-    env:
-      MPLBACKEND: agg
     strategy:
       fail-fast: false
       matrix:
@@ -38,10 +50,10 @@ jobs:
             DEPENDENCIES: matplotlib==3.3 numba==0.52 numpy==1.19 ray[default]==1.13
             LABEL: -oldest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Removed
 
 Fixed
 -----
+- Hough transform figure when ``verbose=2`` is passed to various indexing methods is now
+  plotted in its own figure.
 
 Security
 --------

--- a/pyebsdindex/band_detect.py
+++ b/pyebsdindex/band_detect.py
@@ -362,6 +362,8 @@ class BandDetect:
       im2show[0:rhoMaskTrim,:] = 0
       im2show[-rhoMaskTrim:,:] = 0
       im2show = np.fliplr(im2show)
+
+      plt.figure()
       plt.imshow(im2show, cmap='gray', extent=[self.radonPlan.theta.min(), self.radonPlan.theta.max(),
                                                self.radonPlan.rho.min(), self.radonPlan.rho.max()],
                  interpolation='none', zorder=1, aspect='auto')
@@ -379,7 +381,6 @@ class BandDetect:
         plt.annotate(str(pt + 1), np.squeeze([xplt[pt], yplt[pt]]), color='yellow')
       plt.xlim(0,180)
       plt.ylim(-self.rhoMax, self.rhoMax)
-      plt.show()
 
 
     return bandData

--- a/pyebsdindex/opencl/band_detect_cl.py
+++ b/pyebsdindex/opencl/band_detect_cl.py
@@ -168,21 +168,21 @@ class BandDetect(band_detect.BandDetect):
         im2show[0:rhoMaskTrim,:] = 0
         im2show[-rhoMaskTrim:,:] = 0
         im2show = np.fliplr(im2show)
-        plt.imshow(im2show, cmap='gray', extent = [0, 180, -self.rhoMax, self.rhoMax],
-                   interpolation='none', zorder = 1, aspect='auto')
+        plt.figure()
+        plt.imshow(im2show, cmap='gray', extent=[0, 180, -self.rhoMax, self.rhoMax],
+                   interpolation='none', zorder=1, aspect='auto')
         width = bandData['width'][-1, :]
         width /= width.min()
         width *= 2
         xplt = np.squeeze(180.0 - np.interp(bandData['aveloc'][-1,:,1], np.arange(self.radonPlan.nTheta), self.radonPlan.theta))
         yplt = np.squeeze( -1.0 * np.interp(bandData['aveloc'][-1,:,0], np.arange(self.radonPlan.nRho), self.radonPlan.rho))
 
-        plt.scatter(y=yplt, x=xplt, c='r', s=width, zorder = 2)
+        plt.scatter(y=yplt, x=xplt, c='r', s=width, zorder=2)
 
         for pt in range(self.nBands):
           plt.annotate(str(pt + 1),np.squeeze([xplt[pt],yplt[pt]]), color='yellow')
         plt.xlim(0,180)
         plt.ylim(-self.rhoMax, self.rhoMax)
-        plt.show()
 
 
     except Exception as e: # something went wrong - try the CPU


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Changes:
* Declare new Matplotlib figure before plotting Hough transform. Previously, if a figure already existed, the Hough transform would be added to the first axis of this figure, whatever the figure was. Now the Hough transform is plotted in its own figure, as expected.
* Aspect of Hough transform should be "equal" and not "auto", right? Otherwise it might look square when there are more theta values than rho values, which is misleading in my opinion.

These changes could be released in a 0.1.2 patch release, or in a 0.2.0 minor release if there is some new features coming up.