### PR TITLE
0.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Changelog
 All notable changes to PyEBSDIndex will be documented in this file. The format is based
 on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
 
+0.3.1 (2024-05-24)
+==================
+
+Fixed
+-----
+- Fixed issue when multiple OpenCL platforms are detected.  Will default to discrete GPUs, with whatever platform has the most discrete GPUs attached.  Otherwise, will fall back to integrated graphics.
+
+
 0.3.0 (2024-05-23)
 ==================
 Added

--- a/pyebsdindex/__init__.py
+++ b/pyebsdindex/__init__.py
@@ -7,7 +7,7 @@ __credits__ = [
 ]
 __description__ = "Python based tool for Radon based EBSD indexing"
 __name__ = "pyebsdindex"
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 
 # Try to import only once - also will perform check that at least one GPU is found.

--- a/pyebsdindex/opencl/openclparam.py
+++ b/pyebsdindex/opencl/openclparam.py
@@ -57,9 +57,11 @@ class OpenClParam():
     self.platform = cl.get_platforms()
     return self.platform
   def get_gpu(self):
-
     if self.platform is None:
       self.get_platform()
+
+    if type(self.platform) is not list:
+      self.platform = [self.platform]
 
     pgpudiscrete = np.zeros(len(self.platform), dtype=int)
 


### PR DESCRIPTION
- Fixed issue when multiple OpenCL platforms are detected.  Will default to discrete GPUs, with whatever platform has the most discrete GPUs attached.  Otherwise, will fall back to integrated graphics.
